### PR TITLE
Plinko Bucket Volume Change Logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,13 @@
             <h1 align="center">Volume: <span id="output"></span>%</h1>
             <h2><b>Controls:<br><br>'a' or '←' = Move Left<br><br>'d' or '→' = Move Right<br><br>'Enter' = Spawn Ball</b></h2>
         </div>
+        <div id="footer" class="footer">
+            <h2 id="volume-modifiers" class="volume-modifiers">-100% -90% -80% -70% -60% -50% -40% -30% -20% -10% +0% +10% +20% +30% +40% +50% +60% +70% +80% +90% +100%</h2>
+            <h2>Made by Marco Garzon Lara</h2>
+        </div>
         <script src="vendors/Matter/matter.js"></script>
         <div id="matter-container" class="matter-container">
             <script src="resources/js/physics_world_init.js"></script>
-        </div>
-        <div id="footer" class="footer">
-            <h2>Made by Marco Garzon Lara</h2>
         </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         </div>
         <div id="footer" class="footer">
             <h2 id="volume-modifiers" class="volume-modifiers">-100% -90% -80% -70% -60% -50% -40% -30% -20% -10% +0% +10% +20% +30% +40% +50% +60% +70% +80% +90% +100%</h2>
+            <label for="volume-lock"></label><input type="checkbox" id="volume-lock" class="volume-lock" align="right" onclick="lockVolume()" checked>Volume Limit (Limits max volume to 100%)</label> 
             <h2>Made by Marco Garzon Lara</h2>
         </div>
         <script src="vendors/Matter/matter.js"></script>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             <h2><b>Controls:<br><br>'a' or '←' = Move Left<br><br>'d' or '→' = Move Right<br><br>'Enter' = Spawn Ball</b></h2>
         </div>
         <div id="footer" class="footer">
-            <h2 id="volume-modifiers" class="volume-modifiers">-100% -90% -80% -70% -60% -50% -40% -30% -20% -10% +0% +10% +20% +30% +40% +50% +60% +70% +80% +90% +100%</h2>
+            <h2 id="volume-modifiers" class="volume-modifiers">-100% +90% -80% +70% -60% +50% -40% +30% -20% +10% +0% -10% +20% -30% +40% -50% +60% -70% +80% -90% +100%</h2>
             <label for="volume-lock"></label><input type="checkbox" id="volume-lock" class="volume-lock" align="right" onclick="lockVolume()" checked>Volume Limit (Limits max volume to 100%)</label> 
             <h2>Made by Marco Garzon Lara</h2>
         </div>

--- a/resources/css/styling.css
+++ b/resources/css/styling.css
@@ -30,6 +30,6 @@ body {
 }
 
 #volume-modifiers {
-    font-size: 21px;
+    font-size: 17px;
     padding-bottom: 4%;
 }

--- a/resources/css/styling.css
+++ b/resources/css/styling.css
@@ -1,21 +1,3 @@
-
-/* html {
-    font-family: sans-serif;
-    -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%;
-}
-
-* {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
-
-script {
-    display: none;
-} */
-
 body {
     margin: 0;
     min-height: 100%;
@@ -45,4 +27,9 @@ body {
     bottom: 0;
     width: 100%;
     padding-left: 10px;
+}
+
+#volume-modifiers {
+    font-size: 21px;
+    padding-bottom: 4%;
 }

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -8,7 +8,7 @@
 const matterContainer = document.querySelector("#matter-container"); //Contain the matter world scope/viewport within the matter-container Div.
 const THICCNESS = 60;
 
-let volume = 0;
+let volume = 50; //initial volume value set to 50
 
 // module aliases
 var Engine = Matter.Engine,
@@ -36,7 +36,7 @@ var render = Render.create({
 /**
  * create plinko machine peg collider grid and buckets
  */
-for (let i = 0; i < 15; ++i) {
+for (let i = 0; i < 10; ++i) {
   let Offset = 25;
   for(let j = 0; j < 52; ++j) {
     if(i % 2 == 0) { //if row is even then apply an offset. This displays a plinko-like layout
@@ -62,6 +62,17 @@ for(let i = 0; i < 21; ++i) {
     friction: 0
   });
   Composite.add(engine.world, currentBucket);
+}
+
+//Create the 'detectors' for volume percentage logic
+var volumePercentageZones = []; //create an array structure for the rectangle detectors
+var currentVolumeChange = -100;
+for(let i = 0; i < 21; ++i) {
+  let volumeUpdateRectangle = { xPos: i * (matterContainer.clientWidth / 21), yPos: matterContainer.clientHeight, width: 10, height: 10, isStatic: true, volumeChange: currentVolumeChange }; //container with all the parameters needed for each volume updated and its associated volume percentage increase/decrease
+  volumePercentageZones.push(volumeUpdateRectangle); //store the rectangle detector parameters into the structure
+  if(i > 0) { //This accounts for the additional indices so % doesn't exceed 100
+    currentVolumeChange += 10;
+  }
 }
 
 /**
@@ -92,13 +103,17 @@ Composite.add(engine.world, playerCounter); //Add player to the world
 
 document.addEventListener('keydown', (e) => {  //Spawns particle when spacebar is pressed.
     if (e.key === "Enter") { //Spawn a ball when 'b' is pressed into the world
-        //create circle
-        let circle = Bodies.circle(currentPlayerPosition, 80, 10, {
-            friction: 0.3,
-            frictionAir: 0.00001,
-            restitution: 0.8
-        });
-        Composite.add(engine.world, circle); //add ball to physics world
+      //create circle
+      let circle = Bodies.circle(currentPlayerPosition, 80, 10, {
+          friction: 0.3,
+          frictionAir: 0.01,
+          restitution: 0.9
+      });
+      Composite.add(engine.world, circle); //add ball to physics world
+
+      circle.onCollide((pair) => { //Check for collision with the volume change zones within the buckets
+        
+      }); //This is really gross, but can't do much to decouple right now since refactoring would take so long and the deadline is approaching.
     }
     if(e.key === "Escape") {
       Composite.clear(engine.world, true); //clear all of the spawned balls
@@ -198,13 +213,16 @@ function handleResize(matterContainer) {
   );
 }
 
+/**
+ * Volume modifier numbers for interface
+ */
 let volumeModifiers = document.querySelector("#volume-modifiers")
 let volumeModifierPadding = 10 + "px";
-let volumeModifierSpacing = (((matterContainer.clientWidth / 21) / 2) + 5) + "px";
+let volumeModifierSpacing = ((matterContainer.clientWidth / 21) / 2) + "px";
 console.log(matterContainer.clientWidth);
 volumeModifiers.style.setProperty('padding-left', volumeModifierPadding);
 volumeModifiers.style.setProperty('word-spacing', volumeModifierSpacing);
 
-document.getElementById('output').innerHTML = volume;
+document.getElementById('output').innerHTML = volume; //current volume output to screen
 
 window.addEventListener("resize", () => handleResize(matterContainer));

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -8,7 +8,7 @@
 const matterContainer = document.querySelector("#matter-container"); //Contain the matter world scope/viewport within the matter-container Div.
 const THICCNESS = 60;
 
-let volume = 50; //initial volume value set to 50
+var volume = 50; //initial volume value set to 50
 
 // module aliases
 var Engine = Matter.Engine,
@@ -142,9 +142,11 @@ function zoneCollision(event) {
     
     if(BodyA.label == 'particle' && BodyB.label == 'zone') {
       volume += BodyB.zone;
+      Composite.remove(engine.world, BodyA);
       console.log("bodyB zone is hit.");
     } else if(BodyB.label == 'particle' && BodyA.label == 'zone') {
       volume += BodyA.zone;
+      Composite.remove(engine.world, BodyB);
       console.log("bodyA zone is hit");
     }
     document.getElementById('output').innerHTML = volume; //update current volume output to screen

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -68,11 +68,16 @@ for(let i = 0; i < 21; ++i) {
 var volumePercentageZones = []; //create an array structure for the rectangle detectors
 var currentVolumeChange = -100;
 for(let i = 0; i < 21; ++i) {
-  let volumeUpdateRectangle = { xPos: i * (matterContainer.clientWidth / 21), yPos: matterContainer.clientHeight, width: 10, height: 10, isStatic: true, volumeChange: currentVolumeChange }; //container with all the parameters needed for each volume updated and its associated volume percentage increase/decrease
+  let volumeUpdateRectangle = { xPos: i * (matterContainer.clientWidth / 21) + 50, yPos: matterContainer.clientHeight, width: 100, height: 10, isStatic: true, volumeChange: currentVolumeChange }; //container with all the parameters needed for each volume updated and its associated volume percentage increase/decrease
   volumePercentageZones.push(volumeUpdateRectangle); //store the rectangle detector parameters into the structure
   if(i > 0) { //This accounts for the additional indices so % doesn't exceed 100
     currentVolumeChange += 10;
   }
+}
+
+for(let i = 0; i < volumePercentageZones.length; ++i) {
+  let currentZone = Bodies.rectangle(volumePercentageZones[i].xPos, volumePercentageZones[i].yPos, volumePercentageZones[i].width, volumePercentageZones[i].height, { isStatic: volumePercentageZones[i].isStatic });
+  Composite.add(engine.world, currentZone);
 }
 
 /**

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -68,7 +68,7 @@ for(let i = 0; i < 21; ++i) {
  * Player particle spawner position and spawning logic
  */
 var currentPlayerPosition = matterContainer.clientWidth / 2; //Set the inital player position to middle of viewport
-let playerCounter = Bodies.rectangle(currentPlayerPosition, 70, 10, 10, { //Make the player a rectangle
+let playerCounter = Bodies.rectangle(currentPlayerPosition, 70, 12, 12, { //Make the player a rectangle
   isStatic: true
 });
 document.addEventListener('keydown', (e) => { //player movement controls
@@ -198,6 +198,13 @@ function handleResize(matterContainer) {
   );
 }
 
-window.addEventListener("resize", () => handleResize(matterContainer));
+let volumeModifiers = document.querySelector("#volume-modifiers")
+let volumeModifierPadding = 10 + "px";
+let volumeModifierSpacing = (((matterContainer.clientWidth / 21) / 2) + 5) + "px";
+console.log(matterContainer.clientWidth);
+volumeModifiers.style.setProperty('padding-left', volumeModifierPadding);
+volumeModifiers.style.setProperty('word-spacing', volumeModifierSpacing);
 
 document.getElementById('output').innerHTML = volume;
+
+window.addEventListener("resize", () => handleResize(matterContainer));

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -97,7 +97,14 @@ var currentVolumeChange = -100;
 for(let i = 0; i < 21; ++i) {
   let volumeUpdateRectangle = { xPos: i * (matterContainer.clientWidth / 21) + 50, yPos: matterContainer.clientHeight, width: 100, height: 10, isStatic: true, volumeChange: currentVolumeChange }; //container with all the parameters needed for each volume updated and its associated volume percentage increase/decrease
   volumePercentageZones.push(volumeUpdateRectangle); //store the rectangle detector parameters into the structure
-  currentVolumeChange += 10; //update current volume so each zone has the right change amount
+  console.log(currentVolumeChange);
+  if(i % 2 == 0) { //update each even index so that the bucket modifiers are alternating in negative and positives, not in order. This makes the UI MUCH worse lol.
+    currentVolumeChange = -1 * currentVolumeChange;
+    currentVolumeChange -= 10;
+  } else {
+    currentVolumeChange -= 10; //update current volume so each zone has the right change amount
+    currentVolumeChange = -1 * currentVolumeChange;
+  }
 }
 
 //add zones to composite

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -9,6 +9,29 @@ const matterContainer = document.querySelector("#matter-container"); //Contain t
 const THICCNESS = 60;
 
 var volume = 50; //initial volume value set to 50
+var volumeLock = true;
+
+function lockVolume() {
+  var checkBox = document.getElementById("volume-lock");
+  if (checkBox.checked == true){
+    volume = volumeBounds(volume);
+    document.getElementById('output').innerHTML = volume; //update current volume output to screen
+
+    volumeLock = true;
+  } else {
+    volumeLock = false;
+  }
+  console.log(volumeLock);
+}
+
+function volumeBounds(currentVolume) {   
+  if(currentVolume > 100) {
+    return 100;
+  } else if(currentVolume < 0) {
+    return 0;
+  }
+  return currentVolume;
+}
 
 // module aliases
 var Engine = Matter.Engine,
@@ -142,12 +165,16 @@ function zoneCollision(event) {
     
     if(BodyA.label == 'particle' && BodyB.label == 'zone') {
       volume += BodyB.zone;
+      if(volumeLock == true) {
+        volume = volumeBounds(volume);
+      }
       Composite.remove(engine.world, BodyA);
-      console.log("bodyB zone is hit.");
     } else if(BodyB.label == 'particle' && BodyA.label == 'zone') {
       volume += BodyA.zone;
+      if(volumeLock == true) {
+        volume = volumeBounds(volume);
+      }
       Composite.remove(engine.world, BodyB);
-      console.log("bodyA zone is hit");
     }
     document.getElementById('output').innerHTML = volume; //update current volume output to screen
   }

--- a/resources/js/physics_world_init.js
+++ b/resources/js/physics_world_init.js
@@ -2,7 +2,7 @@
  * Author: Marco Garzon Lara
  * Student Number: 33970651
  * Brief: Unintuitive, physics-based volume mixer UI
- * Notes: This JavaScript file is so gross and coupled I apologise in advance to whoever has to read this, I wrote this on the fly lol.
+ * Notes: This JavaScript file is so gross and coupled I apologise in advance to whoever has to read this, I wrote this on the fly lol. I guess it's fitting since it's a "worst UI" competition :|
  */
 
 const matterContainer = document.querySelector("#matter-container"); //Contain the matter world scope/viewport within the matter-container Div.
@@ -102,12 +102,12 @@ for(let i = 0; i < 21; ++i) {
     currentVolumeChange = -1 * currentVolumeChange;
     currentVolumeChange -= 10;
   } else {
-    currentVolumeChange -= 10; //update current volume so each zone has the right change amount
+    currentVolumeChange -= 10; //update current volume so each zone has the right modifier amount
     currentVolumeChange = -1 * currentVolumeChange;
   }
 }
 
-//add zones to composite
+//add stored zones to composite
 for(let i = 0; i < volumePercentageZones.length; ++i) {
   let currentZone = Bodies.rectangle(volumePercentageZones[i].xPos, volumePercentageZones[i].yPos, volumePercentageZones[i].width, volumePercentageZones[i].height, { 
     isStatic: volumePercentageZones[i].isStatic, 
@@ -170,13 +170,13 @@ function zoneCollision(event) {
     var BodyA = pairs[i].bodyA;
     var BodyB = pairs[i].bodyB;
     
-    if(BodyA.label == 'particle' && BodyB.label == 'zone') {
-      volume += BodyB.zone;
-      if(volumeLock == true) {
-        volume = volumeBounds(volume);
+    if(BodyA.label == 'particle' && BodyB.label == 'zone') { //if a ball particle instance collides with a bucket collider object (bottom of the bucket)
+      volume += BodyB.zone; //add the corresponding zone value to the volume
+      if(volumeLock == true) { //if the volume is capped
+        volume = volumeBounds(volume); //apply the bounds. This basically ensures volume is { 0 < volume > 100 }.
       }
-      Composite.remove(engine.world, BodyA);
-    } else if(BodyB.label == 'particle' && BodyA.label == 'zone') {
+      Composite.remove(engine.world, BodyA); //Remove the colliding ball. This will ensure consistent app framerate as there will be less balls to keep track of
+    } else if(BodyB.label == 'particle' && BodyA.label == 'zone') { //same thing, but in the case that the retrieved pair bodies are switched around.
       volume += BodyA.zone;
       if(volumeLock == true) {
         volume = volumeBounds(volume);


### PR DESCRIPTION
# What Issue Does This Solve

This issue solves the need for the plinko buckets to update the volume value through bucket collision logic.

# How Does It Solve It

It adds the collision and volume update logic needed to be able to adjust the volume with the balls dropped into the plinko machine. Essentially this uses tags (assigned to collision bodies through their Matter.js 'option' parameters) to compare which collision bucket zone the ball has landed into. From here it can deduce how much volume to decrease as the volume modifiers are stored within the plinko bucket zone bodies themselves.

The balls behaviour have also been changed so that they disappear from the scene once they hit a volume modifier collision zone. This makes it so that volume increase and decrease is more accurate and not dependant on how many times a ball bounces with it after colliding with it (i.e. restitution of the ball is no longer affecting the volume change).

# Other Additions

- Added the ability for users to lock the volume level to 100 if they prefer a less loud experience
- Added the percentage text onto the buckets for user interfacing

# Testing Done

- [x] Collision Logic works on multiple browsers as expected
- [x] Volume lock properly sets the limit to 100 
- [x] User input is responsive 
- [ ] Resizing does not break the static collider alignment
- [ ] Optimized for multiple screen resolutions